### PR TITLE
Add .editorconfig for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig — https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Closes #1

Adds a standard `.editorconfig` file with settings matching the project's existing conventions:

- **Charset:** UTF-8
- **Line endings:** LF
- **Indent style:** 2 spaces
- **Final newline:** inserted
- **Trailing whitespace:** trimmed (except in Markdown files, where trailing spaces are meaningful for line breaks)