### PR TITLE
feat: add build:tsc script for plain tsc builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "bun build src/index.ts --compile --outfile buffy",
+    "build:tsc": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     testTimeout: 10000,
+    exclude: ["dist/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
Closes #3

## Summary
- Added `build:tsc` npm script that runs `tsc` to compile TypeScript to `dist/`, providing a build option for users without bun
- Excluded `dist/` from vitest to prevent duplicate test runs when compiled output exists alongside source

## Test plan
- [x] `npm run build:tsc` compiles successfully to `dist/`
- [x] `npm test` runs 47 tests (no duplicates from `dist/`)
- [x] `dist/` already in `.gitignore`