### PR TITLE
feat: add build:tsc script for tsc compilation to dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "tsx src/index.ts",
     "build": "bun build src/index.ts --compile --outfile buffy",
+    "build:tsc": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc --noEmit"


### PR DESCRIPTION
Closes #3

## Summary

- Adds `build:tsc` npm script that runs `tsc` to compile TypeScript to `dist/`
- Supports users who don't have bun installed
- The `tsconfig.json` already had `outDir: "dist"` configured, so the script is simply `tsc`
- `dist/` is already in `.gitignore`

## Test plan

- [x] `npm run build:tsc` compiles successfully to `dist/`
- [x] All 94 existing tests pass
- [x] `dist/` output matches expected structure (cli, comms, config, git, github, hr, roles, tmux, tui, index.js, index.d.ts)