### PR TITLE
chore: add .prettierrc configuration file

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}


### PR DESCRIPTION
Closes #5

Adds a `.prettierrc` file with the requested defaults for TypeScript:

- `semi: true` — require semicolons
- `singleQuote: false` — use double quotes (matches existing code style)
- `trailingComma: "all"` — trailing commas everywhere
- `printWidth: 100` — 100 character line width

These settings are consistent with the formatting conventions already used throughout the codebase.