### PR TITLE
fix: Update LICENSE to year 2025 and Buffy Contributors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Jeremy Hale
+Copyright (c) 2025 Buffy Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #14

Updates the MIT LICENSE file to use:
- Year: 2025
- Copyright holder: Buffy Contributors

as specified in the issue requirements.